### PR TITLE
Add interactive demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ phone) into a reportable form at minimal cost. Once structured address
 data is produced, searching databases such as GNAF for geocoding
 information is much easier!
 
+You can test the capabilities of AddressNet with an interactive demo: [https://address-app.infocruncher.com](https://address-app.infocruncher.com/)
+
 ## Installation
 Get the latest code by installing directly from git using
 ```


### PR DESCRIPTION
I have a deployed a simple AWS hosted web app of this project with its pretrained model at [https://address-app.infocruncher.com](https://address-app.infocruncher.com/)

It's been up and running for over 6 months and isn't going away any time soon. The code is also on GitHub: https://github.com/dylanhogg/address-app

I thought it could be useful to include a link to it for people to kick the tires and evaluate how well it parses addresses.